### PR TITLE
Fixed social icons alignment in contact us section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -910,9 +910,8 @@ text-align:center;
   width: 80%;
   display: flex;
   align-items: center;
-  /* justify-content: flex-; */
-  margin-left:15vw;
-  flex-wrap: wrap;
+  margin: 0 auto;
+  justify-content: center;
   overflow-y: hidden;
   overflow-x: hidden;
 }
@@ -925,6 +924,7 @@ text-align:center;
   border-radius: 50%;
   transition: 0.5s;
   margin-left: 2rem;
+  position: relative;
 }
 
 .contact-social {
@@ -932,6 +932,10 @@ text-align:center;
   line-height: 5.1rem;
   color: var(--primary-background);
   transition: 0.5s;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%,-50%);
 }
 
 .contact-form {


### PR DESCRIPTION

## Related Issue 

social icons alignment problem in  contact us section

- [x] GSSOC Participant  
- [x] Contributor

Closes: #63 

### Describe the changes you've made

changed alignment of the icons

## Type of change

What sort of change have you made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

tested in my browser

## Checklist:

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original 

![Opera Snapshot_2022-03-02_154520_prathimacode-hub github io](https://user-images.githubusercontent.com/82874704/156431103-6a3009aa-76ba-45ae-91de-f3483ecbd45e.png)


Current 


![Opera Snapshot_2022-03-02_154420_prathimacode-hub github io](https://user-images.githubusercontent.com/82874704/156431055-7d2a24b0-f364-40a7-b168-4f5c82d6fd4d.png)
